### PR TITLE
Prevent panic when resolv.conf cannot be read, migrate from native-tls/openssl to rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,10 +693,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -720,12 +734,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.5",
  "rustls-webpki",
  "sct",
 ]
@@ -766,12 +780,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -795,8 +809,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -882,6 +896,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1076,6 +1096,7 @@ dependencies = [
  "derive_more",
  "no-panic",
  "regex",
+ "rustls",
  "rustls-connector",
  "trust-dns-resolver",
  "url",
@@ -1122,6 +1143,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,17 +494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-panic"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6d126424f5ce0bb4587ff4561421d44aeede520541cc66f1bb912506ae46a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,7 +1083,6 @@ dependencies = [
  "clap",
  "crossterm",
  "derive_more",
- "no-panic",
  "regex",
  "rustls",
  "rustls-connector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,27 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,12 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,9 +431,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -521,21 +494,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
+name = "no-panic"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "71a6d126424f5ce0bb4587ff4561421d44aeede520541cc66f1bb912506ae46a"
 dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -564,48 +530,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
-dependencies = [
- "bitflags 2.4.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -647,12 +575,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -785,9 +707,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -806,6 +728,31 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-connector"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060bcc1795b840d0e56d78f3293be5f652aa1611d249b0e63ffe19f4a8c9ae23"
+dependencies = [
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-webpki",
+ "webpki-roots 0.24.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -965,19 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,18 +1064,19 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "trust-dns-proto",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
 name = "ttfb"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "crossterm",
  "derive_more",
- "native-tls",
+ "no-panic",
  "regex",
+ "rustls-connector",
  "trust-dns-resolver",
  "url",
 ]
@@ -1204,12 +1139,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1285,6 +1214,15 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ bin = ["clap", "crossterm"]
 # DNS over systems default DNS resolver
 trust-dns-resolver = { version = "0.23.0", features = ["dns-over-rustls"] }
 # TLS handshake
+rustls = { version = "0.21.8", features = ["dangerous_configuration"] }
 rustls-connector = { version = "0.18.3", features = [
+    "rustls-native-certs",
     "dangerous-configuration",
     "webpki-roots",
     "webpki-roots-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 # nice abstraction of URL
 url = "2.4.1"
 regex = "1.9.5"
-no-panic = "0.1.26"
 
 # +++ BINARY +++
 # used for the binary, not the lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,19 @@ bin = ["clap", "crossterm"]
 # DNS over systems default DNS resolver
 trust-dns-resolver = { version = "0.23.0", features = ["dns-over-rustls"] }
 # TLS handshake
-native-tls = "0.2.11"
+rustls-connector = { version = "0.18.3", features = [
+    "dangerous-configuration",
+    "webpki-roots",
+    "webpki-roots-certs",
+] }
 # automatic Display impl for enums
-derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
+derive_more = { version = "0.99.17", default-features = false, features = [
+    "display",
+] }
 # nice abstraction of URL
 url = "2.4.1"
 regex = "1.9.5"
+no-panic = "0.1.26"
 
 # +++ BINARY +++
 # used for the binary, not the lib
@@ -57,5 +64,5 @@ features = [
     "suggestions",
     "derive",
     "unicode",
-    "wrap_help"
+    "wrap_help",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,18 +33,18 @@ trust-dns-resolver = { version = "0.23.0", features = ["dns-over-rustls"] }
 # TLS handshake
 rustls = { version = "0.21.8", features = ["dangerous_configuration"] }
 rustls-connector = { version = "0.18.3", features = [
-    "rustls-native-certs",
-    "dangerous-configuration",
-    "webpki-roots",
-    "webpki-roots-certs",
+  "rustls-native-certs",
+  "dangerous-configuration",
+  "webpki-roots",
+  "webpki-roots-certs",
 ] }
 # automatic Display impl for enums
 derive_more = { version = "0.99.17", default-features = false, features = [
-    "display",
+  "display",
 ] }
 # nice abstraction of URL
 url = "2.4.1"
-regex = "1.9.5"
+regex = "~1.9.5"
 
 # +++ BINARY +++
 # used for the binary, not the lib
@@ -57,13 +57,13 @@ version = "0.27.0"
 optional = true
 version = "~4.4.4"
 features = [
-    "std",
-    "color",
-    "help",
-    "usage",
-    "error-context",
-    "suggestions",
-    "derive",
-    "unicode",
-    "wrap_help",
+  "std",
+  "color",
+  "help",
+  "usage",
+  "error-context",
+  "suggestions",
+  "derive",
+  "unicode",
+  "wrap_help",
 ]

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ SOFTWARE.
 //! Module for [`TtfbError`].
 
 use derive_more::Display;
-use native_tls::HandshakeError;
+use rustls_connector::HandshakeError;
 use std::error::Error;
 use std::io;
 use std::net::TcpStream;
@@ -85,8 +85,8 @@ pub enum TtfbError {
     CantConnectTcp(io::Error),
     /// Can't establish TLS-Connection.
     #[display(fmt = "Can't establish TLS-Connection because: {}", _0)]
-    CantConnectTls(native_tls::Error),
-    /// Can't verify TLS-Connection.
+    CantConnectTls(rustls_connector::HandshakeError<std::net::TcpStream>),
+    /// Can't verify a TLS-Connection
     #[display(fmt = "Can't verify TLS-Connection because: {}", _0)]
     CantVerifyTls(HandshakeError<TcpStream>),
     /// Can't establish HTTP/1.1-Connection.
@@ -98,6 +98,9 @@ pub enum TtfbError {
     /// There was a problem with the TCP stream.
     #[display(fmt = "There was a problem with the TCP stream because: {}", _0)]
     OtherStreamError(io::Error),
+    /// Can't configure trust-dns-resolver configuration
+    #[display(fmt = "Failed to configure DNS based on system or default settings: {_0}")]
+    CantConfigureDNSError(io::Error),
 }
 
 impl Error for TtfbError {
@@ -108,9 +111,10 @@ impl Error for TtfbError {
             TtfbError::CantConnectTls(err) => Some(err),
             TtfbError::CantConnectTcp(err) => Some(err),
             TtfbError::OtherStreamError(err) => Some(err),
-            TtfbError::CantVerifyTls(err) => Some(err),
             TtfbError::CantConnectHttp(err) => Some(err),
             TtfbError::NoHttpResponse => None,
+            TtfbError::CantConfigureDNSError(err) => Some(err),
+            TtfbError::CantVerifyTls(err) => Some(err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ pub enum TtfbError {
     /// Can't establish TLS-Connection.
     #[display(fmt = "Can't establish TLS-Connection because: {}", _0)]
     CantConnectTls(rustls_connector::HandshakeError<std::net::TcpStream>),
-    /// Can't verify a TLS-Connection
+    /// Can't verify TLS-Connection.
     #[display(fmt = "Can't verify TLS-Connection because: {}", _0)]
     CantVerifyTls(HandshakeError<TcpStream>),
     /// Can't establish HTTP/1.1-Connection.
@@ -98,7 +98,7 @@ pub enum TtfbError {
     /// There was a problem with the TCP stream.
     #[display(fmt = "There was a problem with the TCP stream because: {}", _0)]
     OtherStreamError(io::Error),
-    /// Can't configure trust-dns-resolver configuration
+    /// Can't configure trust-dns-resolver configuration.
     #[display(fmt = "Failed to configure DNS based on system or default settings: {_0}")]
     CantConfigureDNSError(io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ mod tests {
 
 /// Tests that rely on an external network connection.
 /// Sort of integration tests.
-#[cfg(test)]
+#[cfg(all(test, network_tests))]
 mod network_tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,11 @@ SOFTWARE.
 #![deny(rustdoc::all)]
 
 pub use error::{InvalidUrlError, ResolveDnsError, TtfbError};
-use no_panic::no_panic;
 pub use outcome::{DurationPair, TtfbOutcome};
 
 use regex::Regex;
 use rustls::client::{ServerCertVerified, ServerCertVerifier};
-use rustls::{Certificate, ClientConfig, RootCertStore};
+use rustls::{Certificate, ClientConfig};
 use rustls_connector::RustlsConnector;
 use std::io::{Read as IoRead, Write as IoWrite};
 use std::net::{IpAddr, TcpStream};
@@ -103,7 +102,6 @@ impl<T: IoRead + IoWrite> IoReadAndWrite for T {}
 ///
 /// ## Return value
 /// [`TtfbOutcome`] or [`TtfbError`].
-// #[no_panic]
 pub fn ttfb(input: String, allow_insecure_certificates: bool) -> Result<TtfbOutcome, TtfbError> {
     if input.is_empty() {
         return Err(TtfbError::InvalidUrl(InvalidUrlError::MissingInput));
@@ -136,7 +134,6 @@ pub fn ttfb(input: String, allow_insecure_certificates: bool) -> Result<TtfbOutc
 }
 
 /// Initializes the TCP connection to the IP address. Measures the duration.
-// #[no_panic]
 fn tcp_connect(addr: IpAddr, port: u16) -> Result<(TcpStream, Duration), TtfbError> {
     let addr_w_port = (addr, port);
     let now = Instant::now();
@@ -149,7 +146,6 @@ fn tcp_connect(addr: IpAddr, port: u16) -> Result<(TcpStream, Duration), TtfbErr
 /// If the scheme is "https", this replaces the TCP-Stream with a `TLS<TCP>`-stream.
 /// All data will be encrypted using the TLS-functionality of the crate `native-tls`.
 /// If TLS is used, it measures the time of the TLS handshake.
-// #[no_panic]
 fn tls_handshake_if_necessary(
     tcp: TcpStream,
     url: &Url,
@@ -203,7 +199,6 @@ impl ServerCertVerifier for AllowInvalidCertsVerifier {
 
 /// Executes the HTTP/1.1 GET-Request on the given socket. This works with TCP or `TLS<TCP>`.
 /// Afterwards, it waits for the first byte and measures all the times.
-// #[no_panic]
 fn execute_http_get(
     tcp: &mut Box<dyn IoReadAndWrite>,
     url: &Url,
@@ -236,7 +231,6 @@ fn execute_http_get(
 }
 
 /// Constructs the header for a HTTP/1.1 GET-Request.
-// #[no_panic]
 fn build_http11_header(url: &Url) -> String {
     format!(
         "GET {path} HTTP/1.1\r\n\
@@ -252,7 +246,6 @@ fn build_http11_header(url: &Url) -> String {
 }
 
 /// Parses the string input into an [`Url`] object.
-// #[no_panic]
 fn parse_input_as_url(input: &str) -> Result<Url, TtfbError> {
     Url::parse(input)
         .map_err(|e| TtfbError::InvalidUrl(InvalidUrlError::WrongFormat(e.to_string())))
@@ -260,7 +253,6 @@ fn parse_input_as_url(input: &str) -> Result<Url, TtfbError> {
 
 /// Prepends the default scheme "http://" is necessary. Without a scheme, [`parse_input_as_url`]
 /// will fail.
-// #[no_panic]
 fn prepend_default_scheme_if_necessary(url: String) -> String {
     let regex = Regex::new("^(?P<scheme>.*://)?").unwrap();
     let captures = regex.captures(&url);
@@ -274,7 +266,6 @@ fn prepend_default_scheme_if_necessary(url: String) -> String {
 }
 
 /// Assert the scheme is on the allow list. Currently, we only allow "http" and "https".
-// #[no_panic]
 fn assert_scheme_is_allowed(url: &Url) -> Result<(), TtfbError> {
     let allowed_scheme = url.scheme() == "http" || url.scheme() == "https";
     if allowed_scheme {
@@ -287,7 +278,6 @@ fn assert_scheme_is_allowed(url: &Url) -> Result<(), TtfbError> {
 /// Checks from the URL if we already have an IP address or not.
 /// If the user gave us a domain name, we resolve it using the [`trust-dns-resolver`]
 /// crate and measure the time for it.
-// #[no_panic]
 fn resolve_dns_if_necessary(url: &Url) -> Result<(IpAddr, Option<Duration>), TtfbError> {
     Ok(if url.domain().is_none() {
         let mut ip_str = url.host_str().unwrap();
@@ -305,7 +295,6 @@ fn resolve_dns_if_necessary(url: &Url) -> Result<(IpAddr, Option<Duration>), Ttf
 
 /// Actually resolves a domain using the systems default DNS resolver.
 /// Helper function for [`resolve_dns_if_necessary`].
-// #[no_panic]
 fn resolve_dns(url: &Url) -> Result<(IpAddr, Duration), TtfbError> {
     // Construct a new DNS Resolver
     // On Unix/Posix systems, this will read: /etc/resolv.conf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,13 +298,9 @@ fn resolve_dns_if_necessary(url: &Url) -> Result<(IpAddr, Option<Duration>), Ttf
 fn resolve_dns(url: &Url) -> Result<(IpAddr, Duration), TtfbError> {
     // Construct a new DNS Resolver
     // On Unix/Posix systems, this will read: /etc/resolv.conf
-    let resolver = match DnsResolver::from_system_conf() {
-        Ok(v) => v,
-        Err(_) => {
-            // We failed to read from system config for some reason, fall back to trust dns default?
-            DnsResolver::default().map_err(TtfbError::CantConfigureDNSError)?
-        }
-    };
+    let resolver = DnsResolver::from_system_conf()
+        .map_or_else(|_| DnsResolver::default(), Ok)
+        .map_err(TtfbError::CantConfigureDNSError)?;
     let begin = Instant::now();
 
     // at least on Linux this gets cached somehow in the background


### PR DESCRIPTION
1. Fallback to trust-dns-resolver's default configuration if system config cannot be read for some reason
2. Migrate off native-tls and use rustls-connector instead. trust-dns-resolver is already using rustls for DoH, where as native-tls uses openssl. We can reduce dependencies by using rustls directly instead.
3. Added some more network tests for other examples of invalid certificates as well as split them up into separate test functions.