### PR TITLE
Prevent ttfb library from blocking other libraries usage of newer regex version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 ] }
 # nice abstraction of URL
 url = "2.4.1"
-regex = "~1.9.5"
+regex = "^1.9.5"
 
 # +++ BINARY +++
 # used for the binary, not the lib


### PR DESCRIPTION
As title says.

My previous commit caused some issues when updating to 1.8.0 if the workspace importing ttfb was already using (or a dependency of your workspace was already using) Regex 1.10+.